### PR TITLE
Update download_global_DEM parsing

### DIFF
--- a/download_global_DEM.py
+++ b/download_global_DEM.py
@@ -1,7 +1,10 @@
 #! /usr/bin/env python
 
+import os, sys
 import argparse
 import geopandas as gpd
+import rasterio 
+import rasterio.warp
 from fetch_dem import opentopo_utils
 
 def get_parser():
@@ -9,16 +12,19 @@ def get_parser():
         dem_options = ['SRTMGL3', 'SRTMGL3_E', 'SRTMGL1', 'SRTMGL1_E', 'AW3D30', 
                        'AW3D30_E', 'SRTM15Plus', 'SRTM15Plus_E', 'NASADEM', 'NASADEM_E', 
                        'COP30', 'COP30_E', 'COP90', 'COP90_E', 'EU_DTM', 'GEDI_L3']
-        parser.add_argument('-demtype',type=str,default='COP30', \
-                            choices=dem_options,help='Select the DEM intended to be downloaded, postfix "_E" refers to ellipsiodal heights with respect to the WGS84 datum (default: %(default)s)')
-        parser.add_argument('-extent',help="Bounding box extent in single quotes as 'minx miny maxx maxy' in EPSG:4326 (latitude and longitude)",
+        parser.add_argument('-demtype',type=str,default='COP30', choices=dem_options, \
+                help='Select the DEM intended to be downloaded, postfix "_E" refers to ellipsiodal heights with respect to the WGS84 datum (default: %(default)s)')
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('-extent',help="Bounding box extent in single quotes as 'minx miny maxx maxy' in EPSG:4326 (latitude and longitude)",
             type=str,required=False,default=None)
-        parser.add_argument('-poly_fn',help='Vector dataset filename containing polygon specifying desired extent.',
+        group.add_argument('-vector_fn',help='Vector dataset filename specifying desired extent.',
             type=str,required=False,default=None)
+        group.add_argument('-raster_fn',help='Raster dataset filename specifying desired extent.',
+            type=str,required=False,default=None)
+        parser.add_argument('-pad',help='Pad bounds (deg)',type=float,default=0,required=False)
         parser.add_argument('-apikey',help='Opentopgraphy API key',type=str,default='demoapikeyot2022',required=False)
         parser.add_argument('-out_fn',help='Desired output filename, the program appends output horizontal crs EPSG code at the end',type=str,default=None)
         parser.add_argument('-out_proj',type=str,default=None,help='Output EPSG code for horizontal CRS (e.g., EPSG:4326, EPSG:32610); if not provided, will default to opentopography provided horizontal CRS')
-
         return parser
 
 
@@ -28,19 +34,25 @@ def main():
     if args.extent is not None:
         minx,miny,maxx,maxy = args.extent.split(' ')
     else:
-        if args.poly_fn is not None:
-            bound = gpd.read_file(args.poly_fn).to_crs('EPSG:4326')
-            minx,miny,maxx,maxy = bound.total_bounds
-        else:
-            print("Must specifiy bounding box extent or vector filename")
-            sys.exit()
+        #Can likely clean this up to automatically determine if raster or vector fn was provided
+        if args.vector_fn is not None:
+            if os.path.exists(args.vector_fn):
+                bounds = gpd.read_file(args.vector_fn).to_crs('EPSG:4326')
+                minx,miny,maxx,maxy = bound.total_bounds
+            else:
+                sys.exit(f"Input file not found: {args.vector_fn}")
+        elif args.raster_fn is not None:
+            if os.path.exists(args.raster_fn):
+                with rasterio.open(args.raster_fn) as dataset:
+                    bounds = dataset.bounds
+                    bounds = rasterio.warp.transform_bounds(dataset.crs, 'EPSG:4326', *bounds)
+                    minx,miny,maxx,maxy = bounds
+            else:
+                sys.exit(f"Input file not found: {args.raster_fn}")
     bounds = [float(minx),float(miny),float(maxx),float(maxy)]
+    bounds = [bounds[0] - args.pad, bounds[1] - args.pad, bounds[2] + args.pad, bounds[3] + args.pad]
     print(bounds)
     opentopo_utils.get_dem(demtype=args.demtype, bounds=bounds, apikey=args.apikey, out_fn=args.out_fn, proj=args.out_proj)
-    print("Script is complete")
 
 if __name__=="__main__":
     main()
-
-
-


### PR DESCRIPTION
Not tested extensively, but made group parser, and added option to take a raster_fn to define extent.

Change options -poly_fn to -vector_fn, which might break downstream calls.  Can revert back if desired.  I believe there is better support in latest GDAL/OGR to determine if a file is raster or vector, but I didn't have time to look at this.  Had to add rasterio dependency to read raster_fn

Added simple padding in decimal degrees for now.  

We eventually support a CRS argument for the extent/pad values, if they are not EPSG:4326

